### PR TITLE
Improve readPacket performance

### DIFF
--- a/serve_bench_test.go
+++ b/serve_bench_test.go
@@ -1,0 +1,26 @@
+package mqtt
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+)
+
+func BenchmarkReadPacket(b *testing.B) {
+	for _, l := range []int{16, 256, 65536} {
+		b.Run(fmt.Sprintf("%dBytes", l), func(b *testing.B) {
+			data := (&pktPublish{Message: &Message{
+				Topic:   "topicString",
+				Payload: make([]byte, l),
+			}}).pack()
+
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				_, _, _, err := readPacket(bytes.NewReader(data))
+				if err != nil {
+					b.Fatalf("Unexpected error: '%v'", err)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
master
```
pkg: github.com/at-wat/mqtt-go
BenchmarkReadPacket/16Bytes-4         	20712658	       267 ns/op	      82 B/op	       4 allocs/op
BenchmarkReadPacket/256Bytes-4        	14413452	       425 ns/op	     339 B/op	       5 allocs/op
BenchmarkReadPacket/65536Bytes-4      	  288499	     19795 ns/op	   73780 B/op	       6 allocs/op
PASS
ok  	github.com/at-wat/mqtt-go	18.298s
```
this
```
pkg: github.com/at-wat/mqtt-go
BenchmarkReadPacket/16Bytes-4         	31199709	       211 ns/op	      82 B/op	       3 allocs/op
BenchmarkReadPacket/256Bytes-4        	15870556	       342 ns/op	     338 B/op	       3 allocs/op
BenchmarkReadPacket/65536Bytes-4      	  302958	     19453 ns/op	   73778 B/op	       3 allocs/op
PASS
ok  	github.com/at-wat/mqtt-go	18.700s
```
