### PR TITLE
Improve packet pack performance

### DIFF
--- a/connect.go
+++ b/connect.go
@@ -51,7 +51,7 @@ type pktConnect struct {
 	Will          *Message
 }
 
-func (p *pktConnect) pack() []byte {
+func (p *pktConnect) Pack() []byte {
 	payload := packString(p.ClientID)
 
 	var flag byte
@@ -143,7 +143,7 @@ func (c *BaseClient) Connect(ctx context.Context, clientID string, opts ...Conne
 		UserName:      o.UserName,
 		Password:      o.Password,
 		Will:          o.Will,
-	}).pack()
+	}).Pack()
 
 	if err := c.write(pkt); err != nil {
 		return false, wrapError(err, "sending CONNECT")

--- a/connect.go
+++ b/connect.go
@@ -52,7 +52,8 @@ type pktConnect struct {
 }
 
 func (p *pktConnect) Pack() []byte {
-	payload := packString(p.ClientID)
+	payload := make([]byte, 0, packetBufferCap)
+	payload = appendString(payload, p.ClientID)
 
 	var flag byte
 	if p.CleanSession {
@@ -71,16 +72,16 @@ func (p *pktConnect) Pack() []byte {
 		if p.Will.Retain {
 			flag |= byte(connectFlagWillRetain)
 		}
-		payload = append(payload, packString(p.Will.Topic)...)
-		payload = append(payload, packBytes(p.Will.Payload)...)
+		payload = appendString(payload, p.Will.Topic)
+		payload = appendBytes(payload, p.Will.Payload)
 	}
 	if p.UserName != "" {
 		flag |= byte(connectFlagUserName)
-		payload = append(payload, packString(p.UserName)...)
+		payload = appendString(payload, p.UserName)
 	}
 	if p.Password != "" {
 		flag |= byte(connectFlagPassword)
-		payload = append(payload, packString(p.Password)...)
+		payload = appendString(payload, p.Password)
 	}
 	return pack(
 		packetConnect.b(),

--- a/packet.go
+++ b/packet.go
@@ -115,25 +115,38 @@ func remainingLength(n int) []byte {
 	panic("remaining length overflow")
 }
 
+func appendString(b []byte, s string) []byte {
+	return appendBytes(b, []byte(s))
+}
+
+func appendBytes(b, s []byte) []byte {
+	n := len(s)
+	if n > 0xFFFF {
+		panic("string length overflow")
+	}
+	b = appendUint16(b, uint16(n))
+	return append(b, s...)
+}
+
+func appendUint16(b []byte, v uint16) []byte {
+	return append(b,
+		byte(v>>8),
+		byte(v),
+	)
+}
+
 func packString(s string) []byte {
 	return packBytes([]byte(s))
 }
 
 func packBytes(s []byte) []byte {
-	n := len(s)
-	if n > 0xFFFF {
-		panic("string length overflow")
-	}
-	ret := packUint16(uint16(n))
-	ret = append(ret, s...)
-	return ret
+	ret := make([]byte, 0, len(s)+2)
+	return appendBytes(ret, s)
 }
 
 func packUint16(v uint16) []byte {
-	return []byte{
-		byte(v >> 8),
-		byte(v),
-	}
+	ret := make([]byte, 0, 2)
+	return appendUint16(ret, v)
 }
 
 func unpackUint16(b []byte) (int, uint16) {
@@ -158,3 +171,5 @@ func unpackString(b []byte) (int, string, error) {
 	}
 	return int(n) + nHeader, string(rs), nil
 }
+
+const packetBufferCap = 256

--- a/packet_bench_test.go
+++ b/packet_bench_test.go
@@ -1,0 +1,29 @@
+package mqtt
+
+import (
+	"testing"
+)
+
+func BenchmarkPack(b *testing.B) {
+	packets := map[string]interface{ Pack() []byte }{
+		"Connect": &pktConnect{
+			ProtocolLevel: ProtocolLevel4, ClientID: "client",
+			UserName: "user", Password: "pass",
+			Will: &Message{Topic: "topic", Payload: make([]byte, 128)},
+		},
+		"PubAck":      &pktPubAck{},
+		"PubComp":     &pktPubComp{},
+		"Publish":     &pktPublish{&Message{Topic: "topic", Payload: make([]byte, 128)}},
+		"PubRec":      &pktPubRec{},
+		"PubRel":      &pktPubRel{},
+		"Subscribe":   &pktSubscribe{Subscriptions: []Subscription{{Topic: "topic"}}},
+		"Unsubscribe": &pktUnsubscribe{Topics: []string{"topic"}},
+	}
+	for name, p := range packets {
+		b.Run(name, func(b *testing.B) {
+			for i := 0; i < b.N; i++ {
+				_ = p.Pack()
+			}
+		})
+	}
+}

--- a/puback.go
+++ b/puback.go
@@ -29,7 +29,7 @@ func (p *pktPubAck) Parse(flag byte, contents []byte) (*pktPubAck, error) {
 	return p, nil
 }
 
-func (p *pktPubAck) pack() []byte {
+func (p *pktPubAck) Pack() []byte {
 	return pack(
 		packetPubAck.b(),
 		packUint16(p.ID),

--- a/pubcomp.go
+++ b/pubcomp.go
@@ -29,7 +29,7 @@ func (p *pktPubComp) Parse(flag byte, contents []byte) (*pktPubComp, error) {
 	return p, nil
 }
 
-func (p *pktPubComp) pack() []byte {
+func (p *pktPubComp) Pack() []byte {
 	return pack(
 		packetPubComp.b(),
 		packUint16(p.ID),

--- a/publish.go
+++ b/publish.go
@@ -68,7 +68,7 @@ func (p *pktPublish) Parse(flag byte, contents []byte) (*pktPublish, error) {
 	return p, nil
 }
 
-func (p *pktPublish) pack() []byte {
+func (p *pktPublish) Pack() []byte {
 	pktHeader := packetPublish.b()
 
 	if p.Message.Retain {
@@ -137,7 +137,7 @@ func (c *BaseClient) Publish(ctx context.Context, message *Message) error {
 		c.sig.mu.Unlock()
 	}
 
-	pkt := (&pktPublish{Message: message}).pack()
+	pkt := (&pktPublish{Message: message}).Pack()
 	if err := c.write(pkt); err != nil {
 		return wrapError(err, "sending PUBLISH")
 	}
@@ -158,7 +158,7 @@ func (c *BaseClient) Publish(ctx context.Context, message *Message) error {
 			return ctx.Err()
 		case <-chPubRec:
 		}
-		pktPubRel := (&pktPubRel{ID: message.ID}).pack()
+		pktPubRel := (&pktPubRel{ID: message.ID}).Pack()
 		if err := c.write(pktPubRel); err != nil {
 			return wrapError(err, "sending PUBREL")
 		}

--- a/publish.go
+++ b/publish.go
@@ -88,9 +88,10 @@ func (p *pktPublish) Pack() []byte {
 		pktHeader |= byte(publishFlagDup)
 	}
 
-	header := packString(p.Message.Topic)
+	header := make([]byte, 0, packetBufferCap)
+	header = appendString(header, p.Message.Topic)
 	if p.Message.QoS != QoS0 {
-		header = append(header, packUint16(p.Message.ID)...)
+		header = appendUint16(header, p.Message.ID)
 	}
 
 	return pack(

--- a/pubrec.go
+++ b/pubrec.go
@@ -29,7 +29,7 @@ func (p *pktPubRec) Parse(flag byte, contents []byte) (*pktPubRec, error) {
 	return p, nil
 }
 
-func (p *pktPubRec) pack() []byte {
+func (p *pktPubRec) Pack() []byte {
 	return pack(
 		packetPubRec.b(),
 		packUint16(p.ID),

--- a/pubrel.go
+++ b/pubrel.go
@@ -29,7 +29,7 @@ func (p *pktPubRel) Parse(flag byte, contents []byte) (*pktPubRel, error) {
 	return p, nil
 }
 
-func (p *pktPubRel) pack() []byte {
+func (p *pktPubRel) Pack() []byte {
 	return pack(
 		packetPubRel.b()|packetFromClient.b(),
 		packUint16(p.ID),

--- a/serve.go
+++ b/serve.go
@@ -84,12 +84,12 @@ func (c *BaseClient) serve() error {
 				if handler != nil {
 					handler.Serve(publish.Message)
 				}
-				pktPubAck := (&pktPubAck{ID: publish.Message.ID}).pack()
+				pktPubAck := (&pktPubAck{ID: publish.Message.ID}).Pack()
 				if err := c.write(pktPubAck); err != nil {
 					return wrapError(err, "sending PUBACK")
 				}
 			case QoS2:
-				pktPubRec := (&pktPubRec{ID: publish.Message.ID}).pack()
+				pktPubRec := (&pktPubRec{ID: publish.Message.ID}).Pack()
 				if err := c.write(pktPubRec); err != nil {
 					return wrapError(err, "sending PUBREC")
 				}
@@ -133,7 +133,7 @@ func (c *BaseClient) serve() error {
 				delete(subBuffer, pubRel.ID)
 			}
 
-			pktPubComp := (&pktPubComp{ID: pubRel.ID}).pack()
+			pktPubComp := (&pktPubComp{ID: pubRel.ID}).Pack()
 			if err := c.write(pktPubComp); err != nil {
 				return wrapError(err, "sending PUBCOMP")
 			}

--- a/serve_bench_test.go
+++ b/serve_bench_test.go
@@ -12,7 +12,7 @@ func BenchmarkReadPacket(b *testing.B) {
 			data := (&pktPublish{Message: &Message{
 				Topic:   "topicString",
 				Payload: make([]byte, l),
-			}}).pack()
+			}}).Pack()
 
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {

--- a/serve_test.go
+++ b/serve_test.go
@@ -69,7 +69,7 @@ func TestRemainingLengthParse(t *testing.T) {
 
 	// Send PUBLISH from broker.
 	if _, err := ca.Write(
-		(&pktPublish{Message: &Message{Topic: "a", Payload: make([]byte, 256)}}).pack(),
+		(&pktPublish{Message: &Message{Topic: "a", Payload: make([]byte, 256)}}).Pack(),
 	); err != nil {
 		t.Fatalf("Unexpected error: ''%v''", err)
 	}

--- a/subscribe.go
+++ b/subscribe.go
@@ -36,9 +36,9 @@ type pktSubscribe struct {
 }
 
 func (p *pktSubscribe) Pack() []byte {
-	var payload []byte
+	payload := make([]byte, 0, packetBufferCap)
 	for _, sub := range p.Subscriptions {
-		payload = append(payload, packString(sub.Topic)...)
+		payload = appendString(payload, sub.Topic)
 
 		var flag byte
 		switch sub.QoS {

--- a/subscribe.go
+++ b/subscribe.go
@@ -35,7 +35,7 @@ type pktSubscribe struct {
 	Subscriptions []Subscription
 }
 
-func (p *pktSubscribe) pack() []byte {
+func (p *pktSubscribe) Pack() []byte {
 	var payload []byte
 	for _, sub := range p.Subscriptions {
 		payload = append(payload, packString(sub.Topic)...)
@@ -75,7 +75,7 @@ func (c *BaseClient) Subscribe(ctx context.Context, subs ...Subscription) error 
 	c.sig.chSubAck[id] = chSubAck
 	c.sig.mu.Unlock()
 
-	pkt := (&pktSubscribe{ID: id, Subscriptions: subs}).pack()
+	pkt := (&pktSubscribe{ID: id, Subscriptions: subs}).Pack()
 	if err := c.write(pkt); err != nil {
 		return wrapError(err, "sending SUBSCRIBE")
 	}

--- a/unsubscribe.go
+++ b/unsubscribe.go
@@ -23,7 +23,7 @@ type pktUnsubscribe struct {
 	Topics []string
 }
 
-func (p *pktUnsubscribe) pack() []byte {
+func (p *pktUnsubscribe) Pack() []byte {
 	var payload []byte
 	for _, sub := range p.Topics {
 		payload = append(payload, packString(sub)...)
@@ -51,7 +51,7 @@ func (c *BaseClient) Unsubscribe(ctx context.Context, subs ...string) error {
 	c.sig.chUnsubAck[id] = chUnsubAck
 	c.sig.mu.Unlock()
 
-	pkt := (&pktUnsubscribe{ID: id, Topics: subs}).pack()
+	pkt := (&pktUnsubscribe{ID: id, Topics: subs}).Pack()
 	if err := c.write(pkt); err != nil {
 		return wrapError(err, "sending UNSUBSCRIBE")
 	}

--- a/unsubscribe.go
+++ b/unsubscribe.go
@@ -24,9 +24,9 @@ type pktUnsubscribe struct {
 }
 
 func (p *pktUnsubscribe) Pack() []byte {
-	var payload []byte
+	payload := make([]byte, 0, packetBufferCap)
 	for _, sub := range p.Topics {
-		payload = append(payload, packString(sub)...)
+		payload = appendString(payload, sub)
 	}
 
 	return pack(


### PR DESCRIPTION
master
```
BenchmarkPack/Connect-4           	 2547727	       960 ns/op	     560 B/op	      12 allocs/op
BenchmarkPack/PubAck-4            	18677226	       119 ns/op	      16 B/op	       3 allocs/op
BenchmarkPack/PubComp-4           	18505279	       118 ns/op	      16 B/op	       3 allocs/op
BenchmarkPack/Publish-4           	 6111358	       389 ns/op	     184 B/op	       6 allocs/op
BenchmarkPack/PubRec-4            	18211357	       122 ns/op	      16 B/op	       3 allocs/op
BenchmarkPack/PubRel-4 			18601912	       128 ns/op	      16 B/op	       3 allocs/op
BenchmarkPack/Subscribe-4         	 6444253	       328 ns/op	      48 B/op	       6 allocs/op
BenchmarkPack/Unsubscribe-4       	 7415580	       307 ns/op	      48 B/op	       6 allocs/op
```
this
```
BenchmarkPack/Connect-4           	 5289639	       450 ns/op	     208 B/op       5 allocs/op
BenchmarkPack/PubAck-4            	18627781	       122 ns/op	      16 B/op       3 allocs/op
BenchmarkPack/PubComp-4           	19818740	       121 ns/op	      16 B/op       3 allocs/op
BenchmarkPack/Publish-4 		 8932137	       330 ns/op	     176 B/op	       5 allocs/op
BenchmarkPack/PubRec-4  		19060574	       120 ns/op	      16 B/op	       3 allocs/op
BenchmarkPack/PubRel-4  		17996264	       122 ns/op	      16 B/op	       3 allocs/op
BenchmarkPack/Subscribe-4         	14115542	       161 ns/op	      16 B/op       3 allocs/op
BenchmarkPack/Unsubscribe-4       	15310026	       158 ns/op	      16 B/op       3 allocs/op
```