### PR TITLE
Pin mosquitto patch version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
   mosquitto:
-    image: eclipse-mosquitto:2.0
+    image: eclipse-mosquitto:2.0.11
     ports:
       - 1883:1883
       - 8883:8883


### PR DESCRIPTION
Mosquitto 2.0.12 causes connection errors. Use 2.0.11 for now.